### PR TITLE
docs: add module headers and class overview

### DIFF
--- a/esp32/src/BleManager.cpp
+++ b/esp32/src/BleManager.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file BleManager.cpp
+ * @brief Implementazione del gestore BLE basato su NimBLE-Arduino.
+ *
+ * Responsabilità: inizializza e gestisce server, advertising, connessioni e scambio messaggi.
+ * Dipendenze: Arduino core, NimBLE-Arduino.
+ */
+
 #include <Arduino.h>
 #include "BleManager.h"
 

--- a/esp32/src/BleManager.h
+++ b/esp32/src/BleManager.h
@@ -1,3 +1,11 @@
+/**
+ * @file BleManager.h
+ * @brief Gestione del server BLE basato su NimBLE-Arduino.
+ *
+ * Responsabilità: avvia lo stack BLE, gestisce connessioni e I/O.
+ * Dipendenze: Arduino core, NimBLE-Arduino.
+ */
+
 #pragma once
 #include <Arduino.h>
 #include <NimBLEDevice.h>
@@ -12,18 +20,28 @@ class BleManager {
   using OnDisconnectCB = std::function<void()>;
   using OnRxCB         = std::function<void(const String&)>;
 
+  /// Inizializza lo stack BLE con il nome del dispositivo.
   void begin(const char* name);
+  /// Avvia l'advertising del servizio BLE.
   void startAdvertising();
+  /// Ferma l'advertising del servizio BLE.
   void stopAdvertising();
-  void disconnect();  // disconnette se connesso (usa lastConnHandle_)
+  /// Disconnette il client se connesso (usa lastConnHandle_).
+  void disconnect();
 
+  /// Ritorna true se il BLE è abilitato.
   bool isEnabled()   const { return bleEnabled_; }
+  /// Ritorna true se esiste una connessione attiva.
   bool isConnected() const { return bleConnected_; }
 
+  /// Invia una riga di testo sulla caratteristica di notifica.
   void sendLine(const char* line);
 
+  /// Imposta il callback invocato alla connessione.
   void onConnect(OnConnectCB cb)       { onConn_ = cb; }
+  /// Imposta il callback invocato alla disconnessione.
   void onDisconnect(OnDisconnectCB cb) { onDisc_ = cb; }
+  /// Imposta il callback per i messaggi ricevuti.
   void onRx(OnRxCB cb)                 { onRx_ = cb; }
 
  private:

--- a/esp32/src/Buttons.h
+++ b/esp32/src/Buttons.h
@@ -1,3 +1,11 @@
+/**
+ * @file Buttons.h
+ * @brief Gestione di due pulsanti con debounce e long-press.
+ *
+ * Responsabilità: fornisce eventi di pressione breve/lunga.
+ * Dipendenze: Arduino core.
+ */
+
 #pragma once
 #include <Arduino.h>
 
@@ -14,11 +22,14 @@ struct ButtonEvents { bool fell=false; bool rose=false; bool longPress=false; bo
 
 class Buttons {
  public:
+  /// Configura i pin dei pulsanti (pull-up).
   void begin(int pinBle, int pinEvt){
     bBle_.pin = pinBle;  bEvt_.pin = pinEvt;
     pinMode(pinBle, INPUT_PULLUP); pinMode(pinEvt, INPUT_PULLUP);
   }
+  /// Rileva eventi dal pulsante BLE.
   ButtonEvents pollBle(unsigned long longMs){ return poll_(bBle_, longMs); }
+  /// Rileva eventi dal pulsante evento.
   ButtonEvents pollEvt(unsigned long longMs){ return poll_(bEvt_, longMs); }
 
  private:

--- a/esp32/src/DisplayManager.cpp
+++ b/esp32/src/DisplayManager.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file DisplayManager.cpp
+ * @brief Implementazione della gestione del display OLED SSD1306.
+ *
+ * Responsabilità: rende lo stato del sistema su schermo e gestisce animazioni.
+ * Dipendenze: Arduino core, Wire, Adafruit_SSD1306, Adafruit_GFX.
+ */
+
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>

--- a/esp32/src/DisplayManager.h
+++ b/esp32/src/DisplayManager.h
@@ -1,3 +1,11 @@
+/**
+ * @file DisplayManager.h
+ * @brief Gestione del display OLED SSD1306 per lo stato della penna.
+ *
+ * Responsabilità: mostra stato BLE, messaggi e animazioni.
+ * Dipendenze: Arduino core, Adafruit_SSD1306, Adafruit_GFX, Wire.
+ */
+
 #pragma once
 #include <Arduino.h>
 #include "UiState.h"
@@ -7,13 +15,18 @@ class Adafruit_SSD1306;
 
 class DisplayManager {
  public:
+  /// Inizializza il display e prepara le risorse grafiche.
   bool begin();
+  /// Aggiorna eventuali animazioni del display.
   void loop();
 
+  /// Accende o spegne il display in base allo stato del BLE.
   void setBleEnabled(bool on);
+  /// Imposta lo stato dell'interfaccia utente da visualizzare.
   void setUiState(UiState s);
 
   // indicatore "Pose Exti" (ex computation)
+  /// Mostra o nasconde l'indicatore di calcolo posa.
   void setComputing(bool on);
 
  private:

--- a/esp32/src/LedManager.cpp
+++ b/esp32/src/LedManager.cpp
@@ -1,3 +1,11 @@
+/**
+ * @file LedManager.cpp
+ * @brief Implementazione degli effetti LED RGB della penna.
+ *
+ * Responsabilità: applica colori e animazioni in base allo stato.
+ * Dipendenze: Arduino core e API LEDC.
+ */
+
 #include <Arduino.h>
 #include "LedManager.h"
 

--- a/esp32/src/LedManager.h
+++ b/esp32/src/LedManager.h
@@ -1,3 +1,11 @@
+/**
+ * @file LedManager.h
+ * @brief Controllo del LED RGB con effetti di stato.
+ *
+ * Responsabilità: gestisce colori/animazioni secondo lo stato della penna.
+ * Dipendenze: Arduino core e API LEDC.
+ */
+
 #pragma once
 #include <Arduino.h>
 
@@ -12,8 +20,11 @@ enum class LedState {
 
 class LedManager {
  public:
+  /// Configura pin e PWM per il LED RGB.
   void begin(int pinR, int pinG, int pinB, uint32_t freq, uint8_t res, float brightness, bool commonAnode=true);
+  /// Imposta lo stato logico del LED.
   void setState(LedState s);
+  /// Aggiorna le animazioni del LED in base allo stato corrente.
   void loop();
 
  private:

--- a/readme.md
+++ b/readme.md
@@ -62,12 +62,19 @@ Il PC, alla ricezione dell’input, scatta la foto (es. da camera industriale ti
 
 ## 🛠️ Software stack
 
-- **Firmware ESP32 (Arduino/ESP‑IDF)**: BLE GATT, gestione pulsanti, battery-awareness.  
+- **Firmware ESP32 (Arduino/ESP‑IDF)**: BLE GATT, gestione pulsanti, battery-awareness.
 - **PC App (Python)**:
   - **OpenCV** (ArUco, Charuco, solvePnP).
   - **Bleak** (BLE cross‑platform).
   - **Acquisizione camera**: OpenCV/SDK vendor.
   - CLI + opzione GUI minimale (in roadmap).
+
+## 👨‍💻 Classi firmware ESP32
+
+- `BleManager` – wrapper su NimBLE-Arduino per advertising, connessione e scambio messaggi.
+- `DisplayManager` – gestisce il display SSD1306 (stati, animazioni).
+- `LedManager` – controlla il LED RGB e i suoi effetti.
+- `Buttons` – debounce e rilevamento pressioni brevi/lunghe.
 
 ---
 


### PR DESCRIPTION
## Summary
- document ESP32 managers with file headers and Doxygen comments
- add quick reference to main classes in README

## Testing
- `platformio run` *(fails: Not a PlatformIO project)*