### PR TITLE
Document button event timeline and long press detection

### DIFF
--- a/esp32/README.md
+++ b/esp32/README.md
@@ -61,6 +61,17 @@ Il sistema permette di:
   - Alla pressione → invia `START\n`, LED rosso tenue (se connesso), display `Invio…`.
   - Al rilascio → invia `END\n`, ritorno allo stato precedente.
 
+#### Rilevamento long press
+
+```
+tempo (ms): 0    50   550   800
+livello   : HIGH \____LOW____/ HIGH
+               fell longPress  rose
+```
+
+La durata della pressione è `t_rilascio - t_pulsazione`; se supera `longMs`
+si ottiene l'evento `longPress`. Maggiori dettagli in [`docs/buttons.md`](docs/buttons.md).
+
 ---
 
 ## Struttura software

--- a/esp32/docs/buttons.md
+++ b/esp32/docs/buttons.md
@@ -1,0 +1,19 @@
+# Gestione pulsanti
+
+Il file `Buttons.h` implementa il modello di eventi dei pulsanti:
+
+- `fell` – transizione HIGH→LOW (pressione).
+- `rose` – transizione LOW→HIGH (rilascio).
+- `longPress` – generato quando il pulsante resta premuto per almeno `longMs` ms.
+- `isDown` – stato corrente del pulsante (LOW quando premuto).
+
+Esempio con `longMs = 500`:
+
+```
+time (ms): 0    50   550   800
+level    : HIGH \____LOW____/ HIGH
+              fell longPress  rose
+```
+
+`longPress` viene emesso una sola volta per ogni pressione quando `isDown` 
+resta LOW per il tempo indicato.

--- a/esp32/src/Buttons.h
+++ b/esp32/src/Buttons.h
@@ -1,6 +1,19 @@
 #pragma once
 #include <Arduino.h>
 
+/*
+ * Modello eventi pulsante
+ *
+ *  time (ms) : 0    50   550   800
+ *  livello   : HIGH \____LOW____/ HIGH
+ *                fell  longPress  rose
+ *
+ *  fell      -> transizione da rilasciato (HIGH) a premuto (LOW)
+ *  rose      -> transizione da premuto (LOW) a rilasciato (HIGH)
+ *  longPress -> il pulsante resta LOW per `longMs` millisecondi
+ *  isDown    -> stato corrente del pulsante (LOW quando premuto)
+ */
+
 struct Button {
   int pin;
   bool lastStable = true;  // pull-up -> HIGH = rilasciato


### PR DESCRIPTION
## Summary
- Describe button event lifecycle in `Buttons.h` with timeline comments
- Add README diagram explaining long press calculation and link to docs
- Provide dedicated `docs/buttons.md` with button event example

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4e7d40a08331ab3d46bb6e82cce7