### PR TITLE
Remove deprecated sample-dir option from cube CLI

### DIFF
--- a/cube_minimal/README.md
+++ b/cube_minimal/README.md
@@ -15,8 +15,7 @@ Mini-moduli riutilizzabili per:
 from cube_minimal.cube_pose.api import estimate_cube_from_image
 
 res = estimate_cube_from_image(
-    image_or_path="example_1.png",
-    sample_dir="cube_minimal/data/sample_dataset",
+    image_or_path="cube_minimal/data/sample_dataset/example_1.png",
     camera_npz="cube_minimal/config/calib_data.npz",
     aruco_dict="4X4_50",
     marker_size=0.055,  # metri (lato del quadrato nero!)

--- a/cube_minimal/cube_minimal/cli/estimate_one.py
+++ b/cube_minimal/cube_minimal/cli/estimate_one.py
@@ -12,6 +12,9 @@ python -m cube_minimal.cli.estimate_one \
     --pair_strategy first \
     --out overlay.png
 ```
+
+Note that images must now be provided with their full path; the ``--sample-dir``
+option has been removed.
 """
 
 import argparse
@@ -22,7 +25,6 @@ from cube_minimal.cube_pose.api import estimate_cube_from_image
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--image", required=True)
-    ap.add_argument("--sample-dir", default=None, help="cartella con immagini di esempio")
     ap.add_argument("--camera", required=True)
     ap.add_argument("--aruco_dict", default="4X4_50")
     ap.add_argument("--marker_size", type=float, required=True)
@@ -40,7 +42,6 @@ def main():
         cube_size=args.cube_size,
         pair_strategy=args.pair_strategy,
         return_overlay=bool(args.out or args.show),
-        sample_dir=args.sample_dir,
     )
 
     print(f"markers used: {result['num_markers']}")

--- a/cube_minimal/data/sample_dataset/README.md
+++ b/cube_minimal/data/sample_dataset/README.md
@@ -7,10 +7,10 @@ Le immagini `example_*.png` mostrano un cubo con marker ArUco già pronto per la
 
 1. Copia le nuove immagini in questa cartella (`cube_minimal/data/sample_dataset/`).
 2. Usa nomi descrittivi (es. `nuovo_01.png`).
-3. Richiama l'immagine dalla CLI usando l'opzione `--sample-dir`:
+3. Richiama l'immagine dalla CLI specificando il percorso completo con l'opzione `--image`:
 
 ```bash
-python -m cube_minimal.src.cli.estimate_one --sample-dir cube_minimal/data/sample_dataset --image nuovo_01.png --camera <camera.npz> --marker_size <m> --cube_size <m>
+python -m cube_minimal.src.cli.estimate_one --image cube_minimal/data/sample_dataset/nuovo_01.png --camera <camera.npz> --marker_size <m> --cube_size <m>
 ```
 
-Le immagini possono anche essere richiamate direttamente nell'API passando `sample_dir`.
+Le immagini possono anche essere richiamate direttamente nell'API usando il percorso completo.


### PR DESCRIPTION
## Summary
- drop `--sample-dir` argument from `estimate_one` CLI and require full image paths
- align README and sample dataset docs with new usage

## Testing
- `PYTHONPATH=cube_minimal/cube_minimal pytest -q` *(fails: ValueError on missing image path and FileNotFoundError for dummy camera file, KeyError for invalid aruco dict)*

------
https://chatgpt.com/codex/tasks/task_e_68b027a6874c83318c677167ee9945df