### PR TITLE
refactor: update imports and error handling

### DIFF
--- a/cube_minimal/cube_minimal/cube_pose/api.py
+++ b/cube_minimal/cube_minimal/cube_pose/api.py
@@ -55,13 +55,15 @@ def estimate_cube_from_image(
 
     Raises
     ------
+    FileNotFoundError
+        If ``image_or_path`` is a string and the image cannot be read.
     ValueError
-        If the image cannot be read or no markers are detected.
+        If ``image_or_path`` is not a valid BGR array or no markers are detected.
 
     Example
     -------
     ```python
-    from cube_minimal.cube_pose.api import estimate_cube_from_image
+    from cube_minimal.cube_pose import estimate_cube_from_image
     result = estimate_cube_from_image(
         "frame.tiff", "calib.npz", "4X4_50", 0.055, 0.060
     )
@@ -72,10 +74,15 @@ def estimate_cube_from_image(
     if isinstance(image_or_path, str):
         img = cv.imread(image_or_path)
         if img is None:
-            raise ValueError(f"Unable to read image: {image_or_path}")
+            raise FileNotFoundError(f"Unable to read image: {image_or_path}")
     else:
         img = image_or_path
-        if img is None or not isinstance(img, np.ndarray) or img.ndim != 3:
+        if (
+            img is None
+            or not isinstance(img, np.ndarray)
+            or img.ndim != 3
+            or img.shape[2] != 3
+        ):
             raise ValueError("image_or_path must be a path or BGR np.ndarray (H,W,3).")
 
     # Camera

--- a/cube_minimal/cube_minimal/cube_pose/aruco_detect.py
+++ b/cube_minimal/cube_minimal/cube_pose/aruco_detect.py
@@ -25,8 +25,11 @@ class MarkerDetection:
 
 def make_detector(dict_name: str) -> cv.aruco.ArucoDetector:
     """Create an ArUco detector from the dictionary name."""
-
-    d = cv.aruco.getPredefinedDictionary(DICT_MAP[dict_name])
+    try:
+        d = cv.aruco.getPredefinedDictionary(DICT_MAP[dict_name])
+    except KeyError as exc:
+        valid = ", ".join(sorted(DICT_MAP.keys()))
+        raise ValueError(f"Unknown dictionary '{dict_name}'. Valid options: {valid}") from exc
     p = cv.aruco.DetectorParameters()
     return cv.aruco.ArucoDetector(d, p)
 

--- a/cube_minimal/tests/test_api.py
+++ b/cube_minimal/tests/test_api.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from cube_pose.api import estimate_cube_from_image
+from cube_minimal.cube_pose import estimate_cube_from_image
 
 
 def test_nonexistent_image_path_raises():

--- a/cube_minimal/tests/test_aruco_detect.py
+++ b/cube_minimal/tests/test_aruco_detect.py
@@ -1,12 +1,7 @@
-import sys
-from pathlib import Path
 import pytest
 import cv2 as cv
 
-# Add src directory to path for imports
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
-from cube_pose.aruco_detect import make_detector, DICT_MAP
+from cube_minimal.cube_pose.aruco_detect import DICT_MAP, make_detector
 
 
 def test_make_detector_valid():

--- a/cube_minimal/tests/test_pose.py
+++ b/cube_minimal/tests/test_pose.py
@@ -1,15 +1,9 @@
-import sys
-from pathlib import Path
-
 import numpy as np
 import cv2 as cv
 
-# Make cube_minimal/src importable
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
-from cube_pose.aruco_detect import MarkerDetection
-from cube_pose.marker_pose import estimate_marker_poses, MarkerPose
-from cube_pose.cube_pose import estimate_cube_pose
+from cube_minimal.cube_pose.aruco_detect import MarkerDetection
+from cube_minimal.cube_pose.marker_pose import MarkerPose, estimate_marker_poses
+from cube_minimal.cube_pose.cube_pose import estimate_cube_pose
 
 
 def test_estimate_marker_poses_identity():


### PR DESCRIPTION
## Summary
- clean up tests by removing manual sys.path edits and importing from `cube_minimal.cube_pose`
- make `estimate_cube_from_image` raise `FileNotFoundError` for missing images and validate BGR shape
- improve `make_detector` to raise `ValueError` with valid dictionary options

## Testing
- `PYTHONPATH=cube_minimal pytest cube_minimal/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68b027a68db883318231aa434e6653c1