### PR TITLE
Add Basler pypylon camera backend and configuration

### DIFF
--- a/pc/README.md
+++ b/pc/README.md
@@ -117,7 +117,7 @@ py -m venv .venv
 . .\.venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 ```
-> Requisiti principali: `bleak`, `PyYAML`, `opencv-contrib-python`, `numpy`.
+> Requisiti principali: `bleak`, `PyYAML`, `opencv-contrib-python`, `numpy`, `pypylon` (per camere Basler).
 
 ### Configurazione (`config.yaml`)
 Esempio:
@@ -130,8 +130,11 @@ ble:
 capture:
   frequency_ms: 200
   output_root: "captures"
-  use_camera: true
-  camera_id: 0
+  use_camera: true            # false = usa immagini di test da "test_source_dir"
+  camera_type: "opencv"      # "opencv" oppure "pylon" (Basler)
+  camera_id: 0               # solo per camera_type=opencv
+  camera_serial: null        # seriale o IP per camera_type=pylon
+  camera_ip: null
   image_format: "jpg"        # supportati: jpg/png/tif/tiff
   jpeg_quality: 90
   tiff_compression: "lzw"    # opzionale
@@ -173,8 +176,10 @@ runtime:
 - Al **END** la sessione viene messa in coda per la **pose** (in parallelo puoi già iniziare un nuovo `START`).
 
 ### Cattura: Camera reale vs Test mode
-- **Camera reale**: `use_camera: true` → usa `cv2.VideoCapture(camera_id)`.
-- **Test mode**: `use_camera: false` → copia immagini da `test_source_dir` con cadenza `frequency_ms`.  
+- **Camera reale**: `use_camera: true`.
+  - `camera_type: "opencv"` ⇒ backend UVC/OpenCV (`camera_id`).
+  - `camera_type: "pylon"` ⇒ usa **Basler pylon** (`camera_serial` o `camera_ip`).
+- **Test mode**: `use_camera: false` → copia immagini da `test_source_dir` con cadenza `frequency_ms`.
   Se finiscono:
   - `stop_on_test_exhausted: true` ⇒ **termina** la sessione.
   - `false` ⇒ **ricomincia** dall’inizio (ciclo).

--- a/pc/app/capture.py
+++ b/pc/app/capture.py
@@ -8,6 +8,11 @@ try:
 except Exception:
     cv2 = None
 
+try:
+    from pypylon import pylon
+except Exception:  # pragma: no cover - optional dependency
+    pylon = None
+
 class BaseCapture:
     def __init__(self, cfg: dict):
         self.cfg = cfg
@@ -72,6 +77,82 @@ class CameraCapture(BaseCapture):
 
         self.cam.release()
         log("[CAPTURE] Camera rilasciata")
+
+
+class PylonCapture(BaseCapture):
+    """Capture backend using Basler's pypylon SDK."""
+
+    def __init__(self, cfg: dict):
+        super().__init__(cfg)
+        self.cam: Optional["pylon.InstantCamera"] = None
+        self.converter: Optional["pylon.ImageFormatConverter"] = None
+
+    def _open_camera(self, log: Callable[[str], None]):
+        if pylon is None:
+            raise RuntimeError("pypylon non disponibile")
+
+        factory = pylon.TlFactory.GetInstance()
+        serial = self.cfg["capture"].get("camera_serial")
+        ip = self.cfg["capture"].get("camera_ip")
+
+        if serial:
+            serial = str(serial)
+            for dev in factory.EnumerateDevices():
+                if dev.GetSerialNumber() == serial:
+                    self.cam = pylon.InstantCamera(factory.CreateDevice(dev))
+                    break
+            if self.cam is None:
+                raise RuntimeError(f"Nessuna camera con serial {serial}")
+        elif ip:
+            di = pylon.DeviceInfo()
+            di.SetIpAddress(str(ip))
+            self.cam = pylon.InstantCamera(factory.CreateDevice(di))
+        else:
+            self.cam = pylon.InstantCamera(factory.CreateFirstDevice())
+
+        self.cam.Open()
+        self.converter = pylon.ImageFormatConverter()
+        self.converter.OutputPixelFormat = pylon.PixelType_BGR8packed
+        self.converter.OutputBitAlignment = pylon.OutputBitAlignment_MsbAligned
+
+    def capture_loop(self, dest_dir: Path, freq_ms: int, stop_evt, log: Callable[[str], None]):
+        try:
+            self._open_camera(log)
+        except Exception as e:
+            log(f"[CAPTURE] pylon open failed: {e}")
+            return
+
+        log("[CAPTURE] Pylon camera aperta")
+        self.cam.StartGrabbing(pylon.GrabStrategy_LatestImageOnly)
+
+        period = max(0.001, freq_ms / 1000.0)
+        next_t = time.perf_counter()
+        idx = 0
+
+        while not stop_evt.is_set() and self.cam.IsGrabbing():
+            grab = self.cam.RetrieveResult(5000, pylon.TimeoutHandling_ThrowException)
+            if grab.GrabSucceeded():
+                img = self.converter.Convert(grab)
+                frame = img.GetArray()
+                idx += 1
+                ts = time.strftime("%Y%m%d_%H%M%S")
+                fname = f"frame_{idx:06d}_{ts}.{self.image_format}"
+                try:
+                    self._save_image(frame, dest_dir / fname)
+                except Exception as e:
+                    log(f"[CAPTURE] save error: {e}")
+            else:
+                log("[CAPTURE] grab fallita")
+            grab.Release()
+
+            next_t += period
+            sleep = next_t - time.perf_counter()
+            if sleep > 0:
+                time.sleep(sleep)
+
+        self.cam.StopGrabbing()
+        self.cam.Close()
+        log("[CAPTURE] Pylon camera rilasciata")
 
 class TestCapture(BaseCapture):
     def __init__(self, cfg: dict):

--- a/pc/app/config.yaml
+++ b/pc/app/config.yaml
@@ -6,8 +6,11 @@ ble:
 capture:
   frequency_ms: 200
   output_root: "../captures"          # può stare anche in OneDrive; io terrei locale per prestazioni
-  use_camera: false                 # false = test mode (usa immagini da una cartella)
-  camera_id: 0                     # id della webcam (0 di solito va)
+  use_camera: false                 # false = modalità test, copia immagini da "test_source_dir"
+  camera_type: "opencv"            # "opencv" = cv2.VideoCapture, "pylon" = Basler via pypylon
+  camera_id: 0                     # id della webcam (solo per camera_type=opencv)
+  camera_serial: null              # seriale Basler (camera_type=pylon)
+  camera_ip: null                  # IP Basler (camera_type=pylon)
   image_format: "tiff"             # "jpg" o "png"
   jpeg_quality: 90
   tiff_compression: "lzw"          # none | lzw | deflate | packbits

--- a/pc/app/requirements.txt
+++ b/pc/app/requirements.txt
@@ -2,3 +2,4 @@ bleak>=0.22
 PyYAML>=6.0
 opencv-contrib-python>=4.9
 numpy>=1.26
+pypylon>=4.2

--- a/pc/app/session_manager.py
+++ b/pc/app/session_manager.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from capture import CameraCapture, TestCapture
+from capture import CameraCapture, TestCapture, PylonCapture
 
 FMT = "%Y-%m-%d_%H-%M-%S"  # leggibile e ordinabile
 
@@ -32,7 +32,11 @@ class Session:
 
         # capture impl
         if self.use_camera:
-            self.capturer = CameraCapture(self.cfg)
+            cam_type = str(self.cfg["capture"].get("camera_type", "opencv")).lower()
+            if cam_type == "pylon":
+                self.capturer = PylonCapture(self.cfg)
+            else:
+                self.capturer = CameraCapture(self.cfg)
         else:
             self.capturer = TestCapture(self.cfg)
 

--- a/readme.md
+++ b/readme.md
@@ -149,6 +149,11 @@ source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r app/requirements.txt
 ```
 
+Nel file `pc/app/config.yaml` scegli il backend di acquisizione:
+- `camera_type: "opencv"` per webcam/UVC (`camera_id`).
+- `camera_type: "pylon"` per camere Basler (`camera_serial` o `camera_ip`).
+- `use_camera: false` abilita la modalità test (immagini da cartella).
+
 ### 3) Calibrazione camera
 - Stampa una **Charuco** (consigliata) o chessboard.  
 - Usa lo script (da fornire in `pc/app/`) per:


### PR DESCRIPTION
## Summary
- add Basler `pypylon` camera backend with serial or IP connection
- allow selecting capture backend via `camera_type` and new config keys
- document camera setup and install `pypylon`

## Testing
- `pip install pypylon`
- `apt-get install -y libgl1`
- `pip install -e cube_minimal`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b04b5eed908331a27ca5e44349695a