### PR TITLE
docs: describe capture strategy selection

### DIFF
--- a/pc/README.md
+++ b/pc/README.md
@@ -173,9 +173,14 @@ runtime:
 - Al **END** la sessione viene messa in coda per la **pose** (in parallelo puoi già iniziare un nuovo `START`).
 
 ### Cattura: Camera reale vs Test mode
-- **Camera reale**: `use_camera: true` → usa `cv2.VideoCapture(camera_id)`.
-- **Test mode**: `use_camera: false` → copia immagini da `test_source_dir` con cadenza `frequency_ms`.  
-  Se finiscono:
+Scegli la strategia di cattura tramite `capture.use_camera` nel `config.yaml`:
+
+- **Camera reale** (`true`): usa `cv2.VideoCapture(camera_id)` oppure, quando
+  disponibile, l'integrazione Basler `pypylon` per camere industriali.
+  Consigliato quando vuoi testare l'intera pipeline con hardware reale.
+- **Test mode** (`false`): copia immagini da `test_source_dir` con cadenza
+  `frequency_ms`. Ideale per debug, sviluppo offline o integrazione continua.
+  Se le immagini finiscono:
   - `stop_on_test_exhausted: true` ⇒ **termina** la sessione.
   - `false` ⇒ **ricomincia** dall’inizio (ciclo).
 

--- a/pc/app/capture.py
+++ b/pc/app/capture.py
@@ -1,3 +1,20 @@
+"""Capture backends for the PC application.
+
+This module provides a small hierarchy of capture strategies:
+
+* :class:`BaseCapture` defines helpers for persisting frames to disk using the
+  format configured in ``config.yaml``.
+* :class:`CameraCapture` grabs frames from a physical camera through OpenCV's
+  :class:`~cv2.VideoCapture`.  The backend works with a generic UVC webcam and
+  is ready for Basler ``pypylon`` integration once available.
+* :class:`TestCapture` emulates acquisition by copying images from a directory,
+  allowing deterministic runs without any camera.
+
+``SessionManager`` (see :mod:`session_manager`) chooses between
+``CameraCapture`` and ``TestCapture`` based on the ``capture.use_camera`` flag
+in the configuration file.
+"""
+
 import shutil
 import time
 from pathlib import Path

--- a/pc/app/session_manager.py
+++ b/pc/app/session_manager.py
@@ -1,3 +1,18 @@
+"""Session orchestration and capture strategy selection.
+
+This module exposes :class:`SessionManager`, which reacts to BLE commands and
+starts or stops capture sessions.  Each :class:`Session` chooses a concrete
+capture backend according to ``cfg['capture']['use_camera']``:
+
+* ``True`` → :class:`CameraCapture` reads frames from a physical camera (webcam
+  or Basler via ``pypylon`` when integrated).
+* ``False`` → :class:`TestCapture` replays static images from
+  ``test_source_dir`` for deterministic runs.
+
+The flag is typically set in ``pc/app/config.yaml`` and allows developers to
+switch between real hardware and test data without code changes.
+"""
+
 import asyncio
 import shutil
 import threading


### PR DESCRIPTION
## Summary
- document capture classes and configuration-based selection in `capture.py`
- explain capture backend selection in `session_manager`
- clarify real vs test capture modes in README, referencing future Basler support

## Testing
- `python -m py_compile pc/app/capture.py pc/app/session_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04b66647c8331a1d717830f6c8dd6