### PR TITLE
Add marker filtering logic and integrate with pose pipeline

### DIFF
--- a/cube_minimal/cube_minimal/cube_pose/api.py
+++ b/cube_minimal/cube_minimal/cube_pose/api.py
@@ -1,6 +1,6 @@
 ﻿"""High level API to estimate the pose of a cube from a single image."""
 
-from typing import Dict, Any, Union
+from typing import Dict, Any, Optional, Union
 import numpy as np
 import cv2 as cv
 
@@ -8,6 +8,7 @@ from .camera_io import load_camera
 from .aruco_detect import detect_markers
 from .marker_pose import estimate_marker_poses
 from .cube_pose import estimate_cube_pose
+from .filtering.marker_filter import MarkerFilter, MarkerFilterResult
 
 
 def estimate_cube_from_image(
@@ -18,6 +19,8 @@ def estimate_cube_from_image(
     cube_size: float,
     pair_strategy: str = "first",
     return_overlay: bool = False,
+    marker_filter: Optional[MarkerFilter] = None,
+    timestamp: Optional[float] = None,
 ) -> Dict[str, Any]:
     """
     Estimate the cube pose from a single image.
@@ -98,6 +101,15 @@ def estimate_cube_from_image(
     # Marker poses
     poses = estimate_marker_poses(detections, K, dist, marker_size)
 
+    filter_result: Optional[MarkerFilterResult] = None
+    if marker_filter is not None:
+        filter_result = marker_filter.apply(detections, poses, timestamp=timestamp)
+        detections = filter_result.detections
+        poses = filter_result.poses
+
+    if len(poses) == 0:
+        raise ValueError("No markers available after filtering.")
+
     # Cube pose
     cube = estimate_cube_pose(poses, cube_size, pair_strategy=pair_strategy)
 
@@ -135,6 +147,11 @@ def estimate_cube_from_image(
             thickness=2,
         )
 
+    filter_debug = {
+        "discarded_ids": filter_result.discarded_ids if filter_result else [],
+        "corrected_ids": filter_result.corrected_ids if filter_result else [],
+    }
+
     return {
         "tvec": cube.t,
         "rvec": cube.rvec,
@@ -143,4 +160,5 @@ def estimate_cube_from_image(
         "num_markers": len(poses),
         "markers": marker_dicts,
         "overlay": overlay,
+        "marker_filter": filter_debug,
     }

--- a/cube_minimal/cube_minimal/cube_pose/aruco_detect.py
+++ b/cube_minimal/cube_minimal/cube_pose/aruco_detect.py
@@ -15,12 +15,26 @@ DICT_MAP = {
     "APRILTAG_36h11": cv.aruco.DICT_APRILTAG_36h11,
 }
 
+def _contour_area(points: np.ndarray) -> float:
+    pts = points.reshape(-1, 2)
+    if pts.shape[0] < 3:
+        return 0.0
+    x = pts[:, 0]
+    y = pts[:, 1]
+    return float(0.5 * abs(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1))))
+
+
 @dataclass
 class MarkerDetection:
     """Basic detection result for a marker."""
 
     id: int
     corners: np.ndarray  # (4,2) float32, order: tl, tr, br, bl
+    area_px: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.area_px is None:
+            self.area_px = _contour_area(self.corners.astype(np.float32))
 
 
 def make_detector(dict_name: str) -> cv.aruco.ArucoDetector:
@@ -58,5 +72,7 @@ def detect_markers(img_bgr: np.ndarray, dict_name: str) -> List[MarkerDetection]
     if ids is None:
         return out
     for i, mid in enumerate(ids.flatten()):
-        out.append(MarkerDetection(int(mid), corners[i].reshape(4,2).astype(np.float32)))
+        pts = corners[i].reshape(4, 2).astype(np.float32)
+        area = _contour_area(pts)
+        out.append(MarkerDetection(int(mid), pts, area))
     return out

--- a/cube_minimal/cube_minimal/cube_pose/filtering/__init__.py
+++ b/cube_minimal/cube_minimal/cube_pose/filtering/__init__.py
@@ -1,0 +1,5 @@
+"""Filtering helpers for cube marker poses."""
+
+from .marker_filter import MarkerFilter, MarkerFilterResult
+
+__all__ = ["MarkerFilter", "MarkerFilterResult"]

--- a/cube_minimal/cube_minimal/cube_pose/filtering/marker_filter.py
+++ b/cube_minimal/cube_minimal/cube_pose/filtering/marker_filter.py
@@ -1,0 +1,120 @@
+"""Filtering utilities for marker pose stability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+
+from ..aruco_detect import MarkerDetection
+from ..marker_pose import MarkerPose
+
+
+@dataclass
+class _MarkerState:
+    z: float
+    timestamp: Optional[float]
+    area_px: Optional[float]
+
+
+@dataclass
+class MarkerFilterResult:
+    detections: List[MarkerDetection]
+    poses: List[MarkerPose]
+    discarded_ids: List[int]
+    corrected_ids: List[int]
+
+
+class MarkerFilter:
+    """Keep track of markers across frames to filter unstable poses."""
+
+    def __init__(
+        self,
+        active: bool = False,
+        try_adjust: bool = False,
+        area_threshold_px: float = 0.0,
+    ) -> None:
+        self.active = bool(active)
+        self.try_adjust = bool(try_adjust)
+        self.area_threshold_px = float(area_threshold_px)
+        self._state: Dict[int, _MarkerState] = {}
+
+    def reset(self) -> None:
+        self._state.clear()
+
+    def apply(
+        self,
+        detections: Sequence[MarkerDetection],
+        poses: Sequence[MarkerPose],
+        timestamp: Optional[float] = None,
+    ) -> MarkerFilterResult:
+        if len(detections) != len(poses):
+            raise ValueError("Detections and poses must have the same length.")
+
+        if not self.active:
+            used_det = list(detections)
+            used_pose = list(poses)
+            for det, pose in zip(used_det, used_pose):
+                self._update_state(det, pose, timestamp)
+            return MarkerFilterResult(used_det, used_pose, [], [])
+
+        used_detections: List[MarkerDetection] = []
+        used_poses: List[MarkerPose] = []
+        discarded: List[int] = []
+        corrected: List[int] = []
+
+        for det, pose in zip(detections, poses):
+            marker_id = det.id
+            area = det.area_px
+            prev = self._state.get(marker_id)
+
+            keep = True
+            adjusted_pose = pose
+            if prev is None:
+                if self.area_threshold_px > 0 and area is not None:
+                    if area < self.area_threshold_px:
+                        keep = False
+                elif self.area_threshold_px > 0 and area is None:
+                    # Unknown area -> keep the marker but note that we could not evaluate threshold.
+                    keep = True
+            else:
+                prev_z = prev.z
+                current_z = float(np.asarray(pose.tvec).reshape(-1)[2])
+                if prev_z * current_z < 0:
+                    if self.try_adjust:
+                        adjusted_pose = self._flip_pose_z(pose)
+                        corrected.append(marker_id)
+                        current_z = -current_z
+                    else:
+                        keep = False
+                        pass
+
+            if keep:
+                if adjusted_pose is not pose:
+                    used_poses.append(adjusted_pose)
+                else:
+                    used_poses.append(pose)
+                used_detections.append(det)
+                self._update_state(det, adjusted_pose, timestamp)
+            else:
+                discarded.append(marker_id)
+
+        return MarkerFilterResult(used_detections, used_poses, discarded, corrected)
+
+    def _update_state(
+        self,
+        detection: MarkerDetection,
+        pose: MarkerPose,
+        timestamp: Optional[float],
+    ) -> None:
+        z_value = float(np.asarray(pose.tvec).reshape(-1)[2])
+        self._state[detection.id] = _MarkerState(z_value, timestamp, detection.area_px)
+
+    @staticmethod
+    def _flip_pose_z(pose: MarkerPose) -> MarkerPose:
+        new_tvec = np.asarray(pose.tvec, dtype=float).copy()
+        new_tvec = new_tvec.reshape(-1)
+        new_tvec[2] = -new_tvec[2]
+        flipped_tvec = new_tvec.reshape(pose.tvec.shape)
+        return MarkerPose(pose.id, pose.rvec, flipped_tvec, pose.R)

--- a/cube_minimal/tests/test_marker_filter.py
+++ b/cube_minimal/tests/test_marker_filter.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+
+from cube_minimal.cube_pose import api
+from cube_minimal.cube_pose.aruco_detect import MarkerDetection
+from cube_minimal.cube_pose.marker_pose import MarkerPose
+from cube_minimal.cube_pose.filtering.marker_filter import MarkerFilter
+
+
+def _make_pose(marker_id: int, z_value: float) -> MarkerPose:
+    rvec = np.zeros((3, 1), dtype=float)
+    tvec = np.array([[0.0], [0.0], [z_value]], dtype=float)
+    R = np.eye(3, dtype=float)
+    return MarkerPose(marker_id, rvec, tvec, R)
+
+
+def _make_detection(marker_id: int, area: float) -> MarkerDetection:
+    side = float(np.sqrt(area)) if area > 0 else 0.0
+    corners = np.array(
+        [
+            [0.0, 0.0],
+            [side, 0.0],
+            [side, side],
+            [0.0, side],
+        ],
+        dtype=np.float32,
+    )
+    return MarkerDetection(marker_id, corners)
+
+
+def test_marker_filter_discards_small_area():
+    marker_filter = MarkerFilter(active=True, try_adjust=False, area_threshold_px=1500.0)
+    det = _make_detection(1, area=500.0)
+    pose = _make_pose(1, z_value=0.2)
+
+    result = marker_filter.apply([det], [pose])
+
+    assert result.detections == []
+    assert result.poses == []
+    assert result.discarded_ids == [1]
+    assert result.corrected_ids == []
+
+
+def test_marker_filter_discards_flipped_without_adjustment():
+    marker_filter = MarkerFilter(active=True, try_adjust=False)
+    det1 = _make_detection(2, area=2000.0)
+    pose1 = _make_pose(2, z_value=0.3)
+    marker_filter.apply([det1], [pose1])
+
+    det2 = _make_detection(2, area=2000.0)
+    pose2 = _make_pose(2, z_value=-0.3)
+
+    result = marker_filter.apply([det2], [pose2])
+
+    assert result.detections == []
+    assert result.poses == []
+    assert result.discarded_ids == [2]
+    assert result.corrected_ids == []
+
+
+def test_marker_filter_adjusts_flipped_marker():
+    marker_filter = MarkerFilter(active=True, try_adjust=True)
+    det1 = _make_detection(3, area=2000.0)
+    pose1 = _make_pose(3, z_value=0.25)
+    marker_filter.apply([det1], [pose1])
+
+    det2 = _make_detection(3, area=2000.0)
+    pose2 = _make_pose(3, z_value=-0.25)
+
+    result = marker_filter.apply([det2], [pose2])
+
+    assert len(result.detections) == 1
+    assert len(result.poses) == 1
+    assert result.discarded_ids == []
+    assert result.corrected_ids == [3]
+
+    corrected_pose = result.poses[0]
+    assert np.isclose(float(corrected_pose.tvec.reshape(-1)[2]), 0.25)
+
+
+def test_estimate_cube_from_image_respects_filter(monkeypatch, tmp_path):
+    calib_path = tmp_path / "camera.npz"
+    np.savez(calib_path, K=np.eye(3), dist=np.zeros(5))
+
+    area = 500.0
+    corners = np.array(
+        [
+            [0.0, 0.0],
+            [np.sqrt(area), 0.0],
+            [np.sqrt(area), np.sqrt(area)],
+            [0.0, np.sqrt(area)],
+        ],
+        dtype=np.float32,
+    )
+
+    def fake_detect(img, dict_name):
+        return [MarkerDetection(10, corners)]
+
+    def fake_estimate_marker_poses(dets, K, dist, size):
+        return [_make_pose(10, z_value=0.2)]
+
+    monkeypatch.setattr(api, "detect_markers", fake_detect)
+    monkeypatch.setattr(api, "estimate_marker_poses", fake_estimate_marker_poses)
+
+    marker_filter = MarkerFilter(active=True, try_adjust=False, area_threshold_px=1000.0)
+
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError):
+        api.estimate_cube_from_image(
+            image,
+            str(calib_path),
+            "4X4_50",
+            0.05,
+            0.06,
+            marker_filter=marker_filter,
+        )

--- a/pc/app/config.yaml
+++ b/pc/app/config.yaml
@@ -31,6 +31,10 @@ pose:
       "2": "-X"
       "3": "+X"
       "4": "-Z"
+    marker_filter:
+      active_marker_filter: false
+      try_adj_marker: false
+      area_threshold_px: 1500.0
   camera_calibration_npz: "../calib/calib_data.npz"  # must contain 'camera_matrix' and 'dist_coeffs'
 
 runtime:

--- a/pc/app/pose_worker.py
+++ b/pc/app/pose_worker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 from cube_minimal.cube_pose.api import estimate_cube_from_image
+from cube_minimal.cube_pose.filtering.marker_filter import MarkerFilter
 
 from logger import get_logger
 from stream import FramePacket
@@ -37,6 +38,7 @@ class SessionJob:
     end_iso: Optional[str] = None
     finished: asyncio.Event = field(default_factory=asyncio.Event)
     task: Optional[asyncio.Task] = None
+    marker_filter: Optional[MarkerFilter] = None
 
 
 class PoseWorker:
@@ -157,6 +159,7 @@ class PoseWorker:
             label=label,
             save_frames=save_frames,
             save_dir=save_dir,
+            marker_filter=self._create_marker_filter(),
         )
         job.task = asyncio.create_task(self._run_session(job))
         self.sessions[session_key] = job
@@ -191,7 +194,7 @@ class PoseWorker:
                     break
 
                 frame_result, overlay = await asyncio.to_thread(
-                    self._process_frame_packet, packet
+                    self._process_frame_packet, job, packet
                 )
                 job.results["frames"].append(frame_result)
 
@@ -244,10 +247,10 @@ class PoseWorker:
             log.warning(f"Failed to persist frame {path.name}: {exc}")
 
     def _process_frame_packet(
-        self, packet: FramePacket
+        self, job: SessionJob, packet: FramePacket
     ) -> Tuple[dict, Optional["np.ndarray"]]:
         if self.method == "cube" and HAS_CV and hasattr(cv2, "aruco"):
-            return self._process_cube_frame(packet)
+            return self._process_cube_frame(job, packet)
         if self.method == "custom":
             return (
                 {
@@ -266,7 +269,18 @@ class PoseWorker:
             None,
         )
 
-    def _process_cube_frame(self, packet: FramePacket) -> Tuple[dict, Optional["np.ndarray"]]:
+    def _create_marker_filter(self) -> MarkerFilter:
+        cfg = self.pose_cfg.get("marker_filter", {})
+        active = bool(cfg.get("active_marker_filter", False))
+        try_adjust = bool(cfg.get("try_adj_marker", False))
+        threshold = float(cfg.get("area_threshold_px", 0.0) or 0.0)
+        return MarkerFilter(
+            active=active,
+            try_adjust=try_adjust,
+            area_threshold_px=threshold,
+        )
+
+    def _process_cube_frame(self, job: SessionJob, packet: FramePacket) -> Tuple[dict, Optional["np.ndarray"]]:
         pose_cfg = self.pose_cfg
         dict_name = pose_cfg.get("dictionary", "4X4_50")
         marker_size = float(pose_cfg.get("marker_size_mm", 55.0)) / 1000.0
@@ -293,6 +307,8 @@ class PoseWorker:
                 cube_size,
                 pair_strategy=pair_strategy,
                 return_overlay=True,
+                marker_filter=job.marker_filter,
+                timestamp=packet.timestamp,
             )
         except ValueError:
             return (
@@ -323,6 +339,10 @@ class PoseWorker:
             "reproj_err": None,
             "num_markers": int(result.get("num_markers", 0)),
         }
+
+        filter_info = result.get("marker_filter") or {}
+        if filter_info.get("discarded_ids") or filter_info.get("corrected_ids"):
+            frame_entry["marker_filter"] = filter_info
 
         frame_entry["timestamp"] = packet.iso_timestamp
 


### PR DESCRIPTION
## Summary
- add a marker filter that tracks per-id z history, timestamps and area to drop or correct unstable detections
- pass marker metadata through cube estimation, surfacing discarded/corrected ids and hooking the filter into PoseWorker with new config flags
- cover filtering behaviour with unit tests for area thresholds, z flips and automatic correction

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68f8b484757c83319ae976c2c482fc97